### PR TITLE
Update apicurio-registry client library version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <!-- <container.image>test-image:latest</container.image> -->
 
-        <apicurio.registry.version>2.2.0.Final</apicurio.registry.version>
+        <apicurio.registry.version>2.4.1.Final</apicurio.registry.version>
 
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <maven.compiler.target>11</maven.compiler.target>


### PR DESCRIPTION
The apicurio latest version just accepts the latest client version. 

ref: https://github.com/Apicurio/apicurio-registry-examples/issues/40

So let me update the client library version.