### PR TITLE
Bump libraries to solve build errors with supporting oauth

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.parameters>true</maven.compiler.parameters>
-        <compiler-plugin.version>3.9.0</compiler-plugin.version>
+        <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <version.resources.plugin>3.2.0</version.resources.plugin>
         <jandex-plugin.version>1.2.2</jandex-plugin.version>
         <junit.platform.version>1.7.0</junit.platform.version>
@@ -27,10 +27,10 @@
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.16.4.Final</quarkus.platform.version>
         <quarkus-plugin.version>${quarkus.platform.version}</quarkus-plugin.version>
 
-        <quarkus.operator.extension>2.0.3</quarkus.operator.extension>
+        <quarkus.operator.extension>6.0.1</quarkus.operator.extension>
 
         <log4j2.version>2.13.3</log4j2.version>
         <lombok.version>1.18.22</lombok.version>
@@ -74,11 +74,19 @@
                 <groupId>io.quarkiverse.operatorsdk</groupId>
                 <artifactId>quarkus-operator-sdk</artifactId>
                 <version>${quarkus.operator.extension}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
 
             <dependency>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
+                <version>${quarkus.platform.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-vault</artifactId>
                 <version>${quarkus.platform.version}</version>
             </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,8 @@
     <properties>
         <!-- <container.image>test-image:latest</container.image> -->
 
-        <apicurio.registry.version>2.4.1.Final</apicurio.registry.version>
-
+        <apicurio.registry.version>2.4.3.Final</apicurio.registry.version>
+        
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.source>11</maven.compiler.source>

--- a/sync/pom.xml
+++ b/sync/pom.xml
@@ -34,6 +34,11 @@
 
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vault</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy-jackson</artifactId>
         </dependency>
         <dependency>

--- a/sync/src/main/java/io/apicurio/sync/RegistryClientProducer.java
+++ b/sync/src/main/java/io/apicurio/sync/RegistryClientProducer.java
@@ -7,10 +7,18 @@ import javax.inject.Inject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import io.apicurio.registry.rest.client.RegistryClient;
+import io.apicurio.registry.rest.client.impl.ErrorHandler;
 import io.apicurio.registry.rest.client.RegistryClientFactory;
 import io.apicurio.sync.api.labels.ArtifactLabelsHandler;
 import io.vertx.mutiny.core.Vertx;
 import io.vertx.mutiny.ext.web.client.WebClient;
+
+import java.util.Collections;
+
+import io.apicurio.rest.client.JdkHttpClient;
+import io.apicurio.rest.client.auth.Auth;
+import io.apicurio.rest.client.auth.OidcAuth;
+import io.apicurio.rest.client.auth.exception.AuthErrorHandler;
 
 @ApplicationScoped
 public class RegistryClientProducer {
@@ -23,7 +31,15 @@ public class RegistryClientProducer {
 
     @Produces
     public RegistryClient registryClient() {
-        return RegistryClientFactory.create(registryUrl);
+        final String tokenEndpoint = System.getenv("AUTH_TOKEN_ENDPOINT");
+        if (tokenEndpoint != null) {
+            final String authClient = System.getenv("AUTH_CLIENT_ID");
+            final String authSecret = System.getenv("AUTH_CLIENT_SECRET");
+            Auth auth = new OidcAuth(new JdkHttpClient(tokenEndpoint, Collections.emptyMap(), null, new ErrorHandler()), authClient, authSecret);
+            return RegistryClientFactory.create(new JdkHttpClient(registryUrl, Collections.emptyMap(), auth, new ErrorHandler()));
+        } else {
+            return RegistryClientFactory.create(registryUrl);
+        }
     }
 
     @Produces

--- a/sync/src/main/java/io/apicurio/sync/clients/AbstractCustomResourceClient.java
+++ b/sync/src/main/java/io/apicurio/sync/clients/AbstractCustomResourceClient.java
@@ -24,7 +24,7 @@ public abstract class AbstractCustomResourceClient<T extends CustomResource<?, ?
     protected abstract Class<L> getCustomResourceListClass();
 
     protected MixedOperation<T, L, Resource<T>> getResourceClient() {
-        return kubernetesClient.customResources(getCustomResourceClass(), getCustomResourceListClass());
+        return kubernetesClient.resources(getCustomResourceClass(), getCustomResourceListClass());
     }
 
     @PostConstruct

--- a/sync/src/test/java/io/apicurio/sync/ArtifactControllerTest.java
+++ b/sync/src/test/java/io/apicurio/sync/ArtifactControllerTest.java
@@ -66,12 +66,12 @@ public class ArtifactControllerTest {
 
         {
 
-            controller.createOrUpdateResource(artifactv1, null);
+            controller.reconcile(artifactv1, null);
 
             assertEquals(1, registryClient.listArtifactsInGroup(null).getCount().intValue());
             assertEquals(1, registryClient.listArtifactVersions(null, "person", 0, 100).getCount());
 
-            controller.createOrUpdateResource(artifactv1, null);
+            controller.reconcile(artifactv1, null);
             assertEquals(1, registryClient.listArtifactsInGroup(null).getCount().intValue());
             var versions = registryClient.listArtifactVersions(null, "person", 0, 100);
             assertEquals(1, versions.getCount());
@@ -88,7 +88,7 @@ public class ArtifactControllerTest {
 
             //update metadata
             artifactv1.getSpec().setName("person foo");
-            controller.createOrUpdateResource(artifactv1, null);
+            controller.reconcile(artifactv1, null);
             assertEquals(1, registryClient.listArtifactsInGroup(null).getCount().intValue());
             assertEquals(1, registryClient.listArtifactVersions(null, "person", 0, 100).getCount());
             var version1updated = registryClient.getArtifactVersionMetaData(null, "person", "1");
@@ -114,13 +114,13 @@ public class ArtifactControllerTest {
 
         {
 
-            controller.createOrUpdateResource(artifactv2, null);
+            controller.reconcile(artifactv2, null);
 
             assertEquals(1, registryClient.listArtifactsInGroup(null).getCount().intValue());
             var versions = registryClient.listArtifactVersions(null, "person", 0, 100);
             assertEquals(2, versions.getCount());
 
-            controller.createOrUpdateResource(artifactv2, null);
+            controller.reconcile(artifactv2, null);
 
             assertEquals(1, registryClient.listArtifactsInGroup(null).getCount().intValue());
             versions = registryClient.listArtifactVersions(null, "person", 0, 100);
@@ -128,8 +128,8 @@ public class ArtifactControllerTest {
 
         }
 
-        controller.deleteResource(artifactv1, null);
-        controller.deleteResource(artifactv2, null);
+        controller.cleanup(artifactv1, null);
+        controller.cleanup(artifactv2, null);
         assertEquals(0, registryClient.listArtifactsInGroup(null).getCount().intValue());
 
     }

--- a/sync/src/test/resources/artifactTypes/openapi/3.0-petstore_v1.json
+++ b/sync/src/test/resources/artifactTypes/openapi/3.0-petstore_v1.json
@@ -151,7 +151,7 @@
         }
       },
       "Pets": {
-        "type": "array",
+        "type": "object",
         "items": {
           "$ref": "#/components/schemas/Pet"
         }


### PR DESCRIPTION
Sorry, [the previous PR](https://github.com/Apicurio/apicurio-registry-content-sync-operator/pull/135) caused the build error so let me update the libraries to create the image  with supporting oauth

This PR is based on the following PRs:
- [Bump quarkus-operator-sdk from 2.0.3 to 3.0.2 by dependabot[bot] · Pull Request #40 · Apicurio/apicurio-registry-content-sync-operator](https://github.com/Apicurio/apicurio-registry-content-sync-operator/pull/40)
- [Support for OAuth by vsevel · Pull Request #142 · Apicurio/apicurio-registry-content-sync-operator](https://github.com/Apicurio/apicurio-registry-content-sync-operator/pull/142)

Added commits for building the image successfully and making the operator work as expected.

The followings are necessary to be fixed 🤦  (I would be glad if you could share the knowledge on how to fix 🙏 ).

- Make test work
  - Tests are still failing, but docker image build `$ make build-image-faster` has succeeded
- Generate `Pets` bean successfully
  - Pets whose "type": "array" in `sync/src/test/resources/artifactTypes/openapi/3.0-petstore_v1.json` does not produce `Pets` class after upgrading the library :thinking: