### PR TITLE
Add support for schema references

### DIFF
--- a/api/src/main/java/io/apicurio/sync/api/ArtifactReference.java
+++ b/api/src/main/java/io/apicurio/sync/api/ArtifactReference.java
@@ -1,0 +1,46 @@
+package io.apicurio.sync.api;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.sundr.builder.annotations.Buildable;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@Buildable(
+        builderPackage = "io.fabric8.kubernetes.api.builder",
+        editableEnabled = false
+)
+@ToString
+@EqualsAndHashCode
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ArtifactReference {
+
+    private String groupId;
+    private String artifactId;
+    private String version;
+    private String name;
+
+    public String getGroupId() {
+        return groupId;
+    }
+    public void setGroupId(String groupId) {
+        this.groupId = groupId;
+    }
+    public String getArtifactId() {
+        return artifactId;
+    }
+    public void setArtifactId(String artifactId) {
+        this.artifactId = artifactId;
+    }
+    public String getVersion() {
+        return version;
+    }
+    public void setVersion(String version) {
+        this.version = version;
+    }
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/api/src/main/java/io/apicurio/sync/api/ArtifactSpec.java
+++ b/api/src/main/java/io/apicurio/sync/api/ArtifactSpec.java
@@ -48,6 +48,7 @@ public class ArtifactSpec {
 
     private String content;
     private String externalContent;
+    private List<ArtifactReference> references = new ArrayList<>();
 
     public String getGroupId() {
         return groupId;
@@ -126,6 +127,12 @@ public class ArtifactSpec {
     }
     public void setExternalContent(String externalContent) {
         this.externalContent = externalContent;
+    }
+    public List<ArtifactReference> getReferences() {
+       return references;
+    }
+    public void setReferences(List<ArtifactReference> references) {
+        this.references = references;
     }
     public String getModifiedBy() {
         return modifiedBy;

--- a/deploy/simple.yaml
+++ b/deploy/simple.yaml
@@ -30,6 +30,19 @@ spec:
                 type: string
               state:
                 type: string
+              references:
+                items:
+                  properties:
+                    groupId:
+                      type: string
+                    artifactId:
+                      type: string
+                    version:
+                      type: string
+                    name:
+                      type: string
+                  type: object
+                type: array
               content:
                 type: string
               groupId:

--- a/deploy/simple/00-apicurio-registry-kube-sync-crds.yaml
+++ b/deploy/simple/00-apicurio-registry-kube-sync-crds.yaml
@@ -29,6 +29,19 @@ spec:
                 type: string
               state:
                 type: string
+              references:
+                items:
+                  properties:
+                    groupId:
+                      type: string
+                    artifactId:
+                      type: string
+                    version:
+                      type: string
+                    name:
+                      type: string
+                  type: object
+                type: array
               content:
                 type: string
               groupId:

--- a/deploy/standalone/00-apicurio-registry-kube-sync-crds.yaml
+++ b/deploy/standalone/00-apicurio-registry-kube-sync-crds.yaml
@@ -29,6 +29,19 @@ spec:
                 type: string
               state:
                 type: string
+              references:
+                items:
+                  properties:
+                    groupId:
+                      type: string
+                    artifactId:
+                      type: string
+                    version:
+                      type: string
+                    name:
+                      type: string
+                  type: object
+                type: array
               content:
                 type: string
               groupId:

--- a/sync/src/main/java/io/apicurio/sync/controller/ArtifactController.java
+++ b/sync/src/main/java/io/apicurio/sync/controller/ArtifactController.java
@@ -305,13 +305,6 @@ public class ArtifactController implements ResourceController<Artifact> {
         }
     }
 
-    private List<ArtifactReference> toRegistryReferences(
-            List<io.apicurio.sync.api.ArtifactReference> references) {
-        return references.stream()
-                .map(a -> ArtifactReference.builder().artifactId(a.getArtifactId()).groupId(a.getGroupId())
-                        .name(a.getName()).version(a.getVersion()).build()).collect(Collectors.toList());
-    }
-
     private ArtifactMetaData createArtifact(ArtifactSpec spec, byte[] content, IfExists ifExists) {
         List<ArtifactReference> references = toRegistryReferences(spec.getReferences());
         return registryClient.createArtifact(spec.getGroupId(), spec.getArtifactId(), spec.getVersion(),
@@ -373,6 +366,18 @@ public class ArtifactController implements ResourceController<Artifact> {
         meta.setState(vmeta.getState());
 
         return meta;
+    }
+
+    private List<ArtifactReference> toRegistryReferences(
+            List<io.apicurio.sync.api.ArtifactReference> references) {
+        return references.stream()
+                .map(reference -> ArtifactReference.builder()
+                        .artifactId(reference.getArtifactId())
+                        .groupId(reference.getGroupId())
+                        .name(reference.getName())
+                        .version(reference.getVersion())
+                        .build())
+                .collect(Collectors.toList());
     }
 
     private OperationContext<byte[]> getExternalContent(String url) {

--- a/sync/src/main/java/io/apicurio/sync/controller/ArtifactController.java
+++ b/sync/src/main/java/io/apicurio/sync/controller/ArtifactController.java
@@ -2,7 +2,9 @@ package io.apicurio.sync.controller;
 
 import java.io.ByteArrayInputStream;
 import java.time.Duration;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
@@ -13,14 +15,15 @@ import io.apicurio.registry.rest.client.RegistryClient;
 import io.apicurio.registry.rest.client.exception.ArtifactAlreadyExistsException;
 import io.apicurio.registry.rest.client.exception.ArtifactNotFoundException;
 import io.apicurio.registry.rest.client.exception.VersionNotFoundException;
+import io.apicurio.registry.rest.v2.beans.ArtifactContent;
 import io.apicurio.registry.rest.v2.beans.ArtifactMetaData;
+import io.apicurio.registry.rest.v2.beans.ArtifactReference;
 import io.apicurio.registry.rest.v2.beans.EditableMetaData;
 import io.apicurio.registry.rest.v2.beans.IfExists;
 import io.apicurio.registry.rest.v2.beans.UpdateState;
 import io.apicurio.registry.rest.v2.beans.VersionMetaData;
 import io.apicurio.registry.rest.v2.beans.VersionSearchResults;
 import io.apicurio.registry.types.ArtifactState;
-import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.sync.Configuration;
 import io.apicurio.sync.api.Artifact;
 import io.apicurio.sync.api.ArtifactSpec;
@@ -252,27 +255,25 @@ public class ArtifactController implements ResourceController<Artifact> {
             debugLog(spec, "creating artifact");
             try {
                 //try to create artifact, or fail
-                return ArtifactContext.metadata(OperationOutcome.CREATED, registryClient.createArtifact(spec.getGroupId(), spec.getArtifactId(), spec.getVersion(),
-                        spec.getType(),
-                        IfExists.FAIL,
-                        false, new ByteArrayInputStream(content)));
+                return ArtifactContext.metadata(OperationOutcome.CREATED,
+                        createArtifact(spec, content, IfExists.FAIL));
             } catch (ArtifactAlreadyExistsException e) {
                 try {
                     //check what version is this exactly
-                    VersionMetaData vmeta = registryClient.getArtifactVersionMetaDataByContent(spec.getGroupId(), spec.getArtifactId(), false, new ByteArrayInputStream(content));
+                    VersionMetaData vmeta = getArtifactVersionMetaDataByContent(spec, content);
                     debugLog(spec, "artifact version already exists, doing nothing");
                     return ArtifactContext.metadata(OperationOutcome.ALREADY_EXISTS, toMeta(vmeta));
                 } catch (ArtifactNotFoundException nfe) {
                     //artifact exists create new version
                     debugLog(spec, "artifact exists, creating new version");
-                    ArtifactMetaData meta = registryClient.updateArtifact(spec.getGroupId(), spec.getArtifactId(), new ByteArrayInputStream(content));
+                    ArtifactMetaData meta = updateArtifact(spec, content);
                     return ArtifactContext.metadata(OperationOutcome.UPDATED, meta);
                     //TODO catch possible exception?
                 }
             }
         } else {
             try {
-                VersionMetaData vmeta = registryClient.getArtifactVersionMetaDataByContent(spec.getGroupId(), spec.getArtifactId(), false, new ByteArrayInputStream(content));
+                VersionMetaData vmeta = getArtifactVersionMetaDataByContent(spec, content);
                 if (vmeta.getVersion().equals(spec.getVersion())) {
                     debugLog(spec, "version already exists, doing nothing");
                     return ArtifactContext.metadata(OperationOutcome.ALREADY_EXISTS, toMeta(vmeta));
@@ -293,19 +294,44 @@ public class ArtifactController implements ResourceController<Artifact> {
                     registryClient.getArtifactMetaData(spec.getGroupId(), spec.getArtifactId());
                     //artifact exists create new version
                     debugLog(spec, "creating new version");
-                    VersionMetaData vmeta = registryClient.createArtifactVersion(spec.getGroupId(), spec.getArtifactId(), spec.getVersion(), new ByteArrayInputStream(content));
-                    return ArtifactContext.metadata(OperationOutcome.UPDATED, toMeta(vmeta));
+                    return ArtifactContext.metadata(OperationOutcome.UPDATED, updateArtifact(spec, content));
                 } catch (ArtifactNotFoundException e1) {
                     //artifact does not exists at all
                     debugLog(spec, "creating artifact specific version {}");
-                    return ArtifactContext.metadata(OperationOutcome.CREATED, registryClient.createArtifact(spec.getGroupId(), spec.getArtifactId(), spec.getVersion(),
-                            spec.getType(),
-                            IfExists.RETURN,
-                            false, new ByteArrayInputStream(content)));
+                    return ArtifactContext.metadata(OperationOutcome.CREATED,
+                            createArtifact(spec, content, IfExists.RETURN));
                 }
             }
         }
     }
+
+    private List<ArtifactReference> toRegistryReferences(
+            List<io.apicurio.sync.api.ArtifactReference> references) {
+        return references.stream()
+                .map(a -> ArtifactReference.builder().artifactId(a.getArtifactId()).groupId(a.getGroupId())
+                        .name(a.getName()).version(a.getVersion()).build()).collect(Collectors.toList());
+    }
+
+    private ArtifactMetaData createArtifact(ArtifactSpec spec, byte[] content, IfExists ifExists) {
+        List<ArtifactReference> references = toRegistryReferences(spec.getReferences());
+        return registryClient.createArtifact(spec.getGroupId(), spec.getArtifactId(), spec.getVersion(),
+                spec.getType(), ifExists, false, spec.getName(), spec.getDescription(), null, null, null,
+                new ByteArrayInputStream(content), references);
+    }
+
+    private ArtifactMetaData updateArtifact(ArtifactSpec spec, byte[] content) {
+        List<ArtifactReference> references = toRegistryReferences(spec.getReferences());
+        return registryClient.updateArtifact(spec.getGroupId(), spec.getArtifactId(), spec.getVersion(), null,
+                null, new ByteArrayInputStream(content), references);
+    }
+
+    private VersionMetaData getArtifactVersionMetaDataByContent(ArtifactSpec spec, byte[] content) {
+        List<ArtifactReference> references = toRegistryReferences(spec.getReferences());
+
+        return registryClient.getArtifactVersionMetaDataByContent(spec.getGroupId(), spec.getArtifactId(),
+                false, ArtifactContent.builder().content(new String(content)).references(references).build());
+    }
+
 
     private ArtifactStatus getStatus(Artifact artifact) {
         ArtifactStatus status = Optional.ofNullable(artifact.getStatus())

--- a/sync/src/main/resources/application.properties
+++ b/sync/src/main/resources/application.properties
@@ -17,5 +17,5 @@ quarkus.operator-sdk.namespaces=${WATCH_NAMESPACES}
 # tests
 %test.quarkus.log.level=INFO
 %test.quarkus.apicurio-registry.devservices.enabled=true
-%test.quarkus.apicurio-registry.devservices.image-name=quay.io/apicurio/apicurio-registry-mem:2.1.5.Final
+%test.quarkus.apicurio-registry.devservices.image-name=quay.io/apicurio/apicurio-registry-mem:2.4.2.Final
 %test.quarkus.apicurio-registry.devservices.port=8181

--- a/sync/src/test/resources/artifactTypes/protobuf/person_v1.proto
+++ b/sync/src/test/resources/artifactTypes/protobuf/person_v1.proto
@@ -1,0 +1,16 @@
+syntax = "proto2";
+
+import "phone_number.proto";
+
+package tutorial;
+
+option java_package = "com.example.tutorials";
+option java_outer_classname = "PersonProtos";
+
+message Person {
+  required string name = 1;
+  required int32 id = 2;
+  optional string email = 3;
+
+  repeated PhoneNumber phones = 4;
+}

--- a/sync/src/test/resources/artifactTypes/protobuf/person_v2.proto
+++ b/sync/src/test/resources/artifactTypes/protobuf/person_v2.proto
@@ -1,0 +1,18 @@
+syntax = "proto2";
+
+import "phone_number.proto";
+
+package tutorial;
+
+option java_package = "com.example.tutorials";
+option java_outer_classname = "PersonProtos";
+
+message Person {
+  required string name = 1;
+  required int32 id = 2;
+  optional string email = 3;
+
+  repeated PhoneNumber phones = 4;
+
+  optional int32 age = 5;
+}

--- a/sync/src/test/resources/artifactTypes/protobuf/phone_number.proto
+++ b/sync/src/test/resources/artifactTypes/protobuf/phone_number.proto
@@ -1,0 +1,17 @@
+syntax = "proto2";
+
+package tutorial;
+
+option java_package = "com.example.tutorials";
+option java_outer_classname = "PhoneNumberProtos";
+
+enum PhoneType {
+  MOBILE = 0;
+  HOME = 1;
+  WORK = 2;
+}
+
+message PhoneNumber {
+  required string number = 1;
+  optional PhoneType type = 2 [default = HOME];
+}


### PR DESCRIPTION
This change adds the support for schema referencing. The references support has been added to apicurio registry I believe in version 2.2.2, but the sync operator was not able to handle that. The version of apicurio registry used in tests had to be bumped because version 2.1.5 was not supporting references and there has been quite a few fixes touching references in various releases therefore I landed on version 2.4.2.

After this the operator won't longer work with older versions of apicurio registry